### PR TITLE
Create hooks directory if it doesn't exist

### DIFF
--- a/lib/mix/tasks/multi_select.install.ex
+++ b/lib/mix/tasks/multi_select.install.ex
@@ -108,6 +108,11 @@ defmodule Mix.Tasks.MultiSelect.Install do
       File.mkdir!(hooks_folder)
     end
 
+    index_file = "assets/js/hooks/index.js"
+    unless File.exists?(index_file) do
+      File.touch!(index_file)
+    end
+
     file = "multi-select-hook.js"
     path = "assets/js/hooks/#{file}"
     src  = "#{Mix.Project.deps_paths()[:phoenix_multi_select]}/assets/#{file}"

--- a/lib/mix/tasks/multi_select.install.ex
+++ b/lib/mix/tasks/multi_select.install.ex
@@ -104,14 +104,10 @@ defmodule Mix.Tasks.MultiSelect.Install do
 
   defp install_js_hook() do
     hooks_folder = "assets/js/hooks"
-    unless File.exists?(hooks_folder) do
-      File.mkdir!(hooks_folder)
-    end
+    index_file   = "assets/js/hooks/index.js"
 
-    index_file = "assets/js/hooks/index.js"
-    unless File.exists?(index_file) do
-      File.touch!(index_file)
-    end
+    File.exists?(hooks_folder) || File.mkdir!(hooks_folder)
+    File.exists?(index_file)   || File.touch!(index_file)
 
     file = "multi-select-hook.js"
     path = "assets/js/hooks/#{file}"

--- a/lib/mix/tasks/multi_select.install.ex
+++ b/lib/mix/tasks/multi_select.install.ex
@@ -103,6 +103,11 @@ defmodule Mix.Tasks.MultiSelect.Install do
   end
 
   defp install_js_hook() do
+    hooks_folder = "assets/js/hooks"
+    unless File.exists?(hooks_folder) do
+      File.mkdir!(hooks_folder)
+    end
+
     file = "multi-select-hook.js"
     path = "assets/js/hooks/#{file}"
     src  = "#{Mix.Project.deps_paths()[:phoenix_multi_select]}/assets/#{file}"


### PR DESCRIPTION
I tried installing on a fresh phoenix application where the hooks folder didn't exist and got an error.