### PR TITLE
Assign `selected_count` when assigning checked options to allow the display of tags on initial render

### DIFF
--- a/lib/multi_select.ex
+++ b/lib/multi_select.ex
@@ -208,10 +208,14 @@ defmodule Phoenix.LiveView.Components.MultiSelect do
   def update(%{options: options} = params, socket) do
     socket  = assign(socket, params)
     assigns = socket.assigns
+
+    checked_options = filter_checked_options(options)
+
     assigns =
       assigns
       |> assign_new(:filter_id,   fn -> "#{assigns.id}-filter" end)
-      |> assign(:checked_options, filter_checked_options(options))
+      |> assign(:checked_options, checked_options)
+      |> assign(:selected_count, length(checked_options))
       |> init_rest(false)
 
     {:ok, Map.put(socket, :assigns, assigns)}


### PR DESCRIPTION
**Bug:**
When we are providing the component with a list of selected options during the first render, the tags are not shown. They are only shown after we check or uncheck an option.

**What the issue is:** 
The `selected_count` assign is only set when we check or uncheck an option. This `selected_count` value is what is deciding whether the placeholder or a list of tags is shown.

**Solution**:
We can set the `selected_count` assign in the `update` method because we already have the list of selected options.